### PR TITLE
LUGG-1188 Reduce specificity of css selector

### DIFF
--- a/css/luggage_story.css
+++ b/css/luggage_story.css
@@ -1,4 +1,4 @@
-.view-id-stories.view-display-id-page .views-field-title h2 {
+.view-id-stories .views-field-title h2 {
   text-align: center;
   margin-bottom: 0;
   font-size: 1.25rem;
@@ -12,15 +12,15 @@
   margin-bottom: 1rem;
 }
 
-.view-id-stories.view-display-id-page .views-field-field-story-images {
+.view-id-stories .views-field-field-story-images {
   margin-bottom: 1rem;
 }
 
-.view-id-stories.view-display-id-page .views-field-field-story-images a {
+.view-id-stories .views-field-field-story-images a {
   display: block;
 }
 
-.view-id-stories.view-display-id-page .views-field-field-story-images img {
+.view-id-stories .views-field-field-story-images img {
   margin: 0;
   border-radius: 0.15rem;
 }


### PR DESCRIPTION
Any other story page views are not catching the story design. I think it's better to have any story views look consistent and revert with custom rather than have to use custom to enforce default design.